### PR TITLE
add test

### DIFF
--- a/tests/moviedata/extended/tables/test_release_dates_table.py
+++ b/tests/moviedata/extended/tables/test_release_dates_table.py
@@ -1,0 +1,44 @@
+from datetime import date
+from typing import Callable
+
+from movielog.moviedata.extended.movies import Movie
+from movielog.moviedata.extended.tables import release_dates_table
+from tests.conftest import QueryResult
+
+
+def test_update_adds_release_dates(sql_query: Callable[[str], QueryResult]) -> None:
+    expected = [
+        {
+            "movie_imdb_id": "tt0053221",
+            "release_date": "1959-03-18",
+            "notes": "(limited)",
+        },
+        {"movie_imdb_id": "tt0092106", "release_date": "1986-08-08", "notes": ""},
+    ]
+
+    movies = [
+        Movie(
+            imdb_id="tt0092106",
+            sort_title="Transformers: The Movie (1986)",
+            directors=[],
+            writers=[],
+            cast=[],
+            release_date=date(1986, 8, 8),
+            release_date_notes="",
+            countries=["United States", "Japan"],
+        ),
+        Movie(
+            imdb_id="tt0053221",
+            sort_title="Rio Bravo (1959)",
+            directors=[],
+            writers=[],
+            cast=[],
+            release_date=date(1959, 3, 18),
+            release_date_notes="(limited)",
+            countries=["United States"],
+        ),
+    ]
+
+    release_dates_table.update(movies)
+
+    assert sql_query("select * from release_dates order by release_date") == expected

--- a/tests/moviedata/extended/tables/test_sort_titles_table.py
+++ b/tests/moviedata/extended/tables/test_sort_titles_table.py
@@ -1,0 +1,43 @@
+from datetime import date
+from typing import Callable
+
+from movielog.moviedata.extended.movies import Movie
+from movielog.moviedata.extended.tables import sort_titles_table
+from tests.conftest import QueryResult
+
+
+def test_update_adds_sort_titles(sql_query: Callable[[str], QueryResult]) -> None:
+    expected = [
+        {
+            "movie_imdb_id": "tt0053221",
+            "sort_title": "Rio Bravo (1959)",
+        },
+        {"movie_imdb_id": "tt0092106", "sort_title": "Transformers: The Movie (1986)"},
+    ]
+
+    movies = [
+        Movie(
+            imdb_id="tt0092106",
+            sort_title="Transformers: The Movie (1986)",
+            directors=[],
+            writers=[],
+            cast=[],
+            release_date=date(1986, 8, 8),
+            release_date_notes="",
+            countries=["United States", "Japan"],
+        ),
+        Movie(
+            imdb_id="tt0053221",
+            sort_title="Rio Bravo (1959)",
+            directors=[],
+            writers=[],
+            cast=[],
+            release_date=date(1959, 3, 18),
+            release_date_notes="(limited)",
+            countries=["United States"],
+        ),
+    ]
+
+    sort_titles_table.update(movies)
+
+    assert sql_query("select * from sort_titles order by movie_imdb_id") == expected


### PR DESCRIPTION
- add test
- add test
- add test
- refactor api
- add test
- refactor/add tests
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add tests
- add tests
- add test
- add test
- add test
- add test
- add test
- add tests
- add test
- add test
- add test
- add test
- add test
- add test
- add test
