### PR TITLE
add test

### DIFF
--- a/movielog/moviedata/extended/release_dates.py
+++ b/movielog/moviedata/extended/release_dates.py
@@ -51,7 +51,6 @@ def parse_release_dates(raw_release_dates: list[Dict[str, str]]) -> list[Release
 
 def parse(imdb_movie: imdb.Movie.Movie) -> ReleaseDate:
     raw_release_dates = imdb_movie.get("raw release dates")
-
     if not raw_release_dates:
         return no_release_date(imdb_movie)
 

--- a/movielog/reviews/api.py
+++ b/movielog/reviews/api.py
@@ -17,8 +17,7 @@ def save(review: Review) -> str:
     return serializer.serialize(review)
 
 
-def export_data() -> None:
-    exports_api.export()
+export_data = exports_api.export
 
 
 def create(  # noqa: WPS211

--- a/tests/moviedata/extended/test_release_dates.py
+++ b/tests/moviedata/extended/test_release_dates.py
@@ -21,3 +21,18 @@ def test_parse_returns_empty_release_date_if_raw_release_dates_malformed() -> No
     expected = release_dates.ReleaseDate(date=date(2001, 1, 1), notes="No release date")
 
     assert expected == release_dates.parse(movie)
+
+
+def test_parse_notes_release_date_incongruity() -> None:
+    movie = imdb.Movie.Movie(
+        data={
+            "year": 2001,
+            "raw release dates": [{"date": "12 March 1999", "notes": "(premier)"}],
+        }
+    )
+
+    expected = release_dates.ReleaseDate(
+        date=date(2001, 1, 1), notes="Given release date: 1999-03-12 (premier)"
+    )
+
+    assert expected == release_dates.parse(movie)


### PR DESCRIPTION
- add test
- add test
- add test
- refactor api
- add test
- refactor/add tests
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add tests
- add tests
- add test
- add test
- add test
- add test
- add test
- add tests
- add test
- add test
- add test
- add test
- add test
- add test
- add test
- add tests
