### PR TITLE
Fix RadioList AttributeError on menu selection

### DIFF
--- a/movielog/cli/radio_list.py
+++ b/movielog/cli/radio_list.py
@@ -32,7 +32,7 @@ class RadioList[T]:
 
     def __init__(self, options: Sequence[tuple[T, AnyFormattedText]]) -> None:
         self.options = options
-        self.current_option: T = options[0][0]
+        self.current_value: T | None = None
         self._selected_index = 0
 
         # Key bindings.


### PR DESCRIPTION
## Summary
- Fixed AttributeError when selecting menu options in RadioList
- Changed `current_option` to `current_value` to match the attribute used in `_handle_enter`
- Initialized to `None` to represent no selection

## Context
This is the same bug that was fixed in booklog PR #741. The RadioList class had a mismatch between the attribute name defined in `__init__` and the one used in `_handle_enter`, causing crashes when users selected any menu option.

## Test plan
- [x] Run existing tests with `uv run pytest`
- [x] Manually test CLI menu navigation
- [x] All checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)