### PR TITLE
Make collection description a required field

### DIFF
--- a/movielog/cli/new_collection.py
+++ b/movielog/cli/new_collection.py
@@ -5,4 +5,6 @@ from movielog.repository import api as repository_api
 def prompt() -> None:
     name = ask.prompt("Collection name: ")
     if name and confirm.prompt(f"<cyan>{name}</cyan>?"):
-        repository_api.new_collection(name)
+        description = ask.prompt("Collection description: ")
+        if description:
+            repository_api.new_collection(name, description)

--- a/movielog/cli/select_person.py
+++ b/movielog/cli/select_person.py
@@ -44,6 +44,5 @@ def build_options(search_results: Iterable[SearchResult]) -> list[Option]:
         return [(None, "Search Again")]
 
     return [
-        (search_result, result_to_html_string(search_result))
-        for search_result in search_results
+        (search_result, result_to_html_string(search_result)) for search_result in search_results
     ]

--- a/movielog/cli/select_title.py
+++ b/movielog/cli/select_title.py
@@ -42,9 +42,7 @@ def confirm_selected_title(selected_title: SearchResult) -> bool:
 def result_to_html_string(search_result: SearchResult) -> str:
     return "<cyan>{}</cyan> ({})".format(
         html.escape(search_result.full_title),
-        ", ".join(
-            html.escape(principal) for principal in search_result.principal_cast_names
-        ),
+        ", ".join(html.escape(principal) for principal in search_result.principal_cast_names),
     )
 
 
@@ -53,6 +51,5 @@ def build_options(search_results: Iterable[SearchResult]) -> list[Option]:
         return [(None, "Search Again")]
 
     return [
-        (search_result, result_to_html_string(search_result))
-        for search_result in search_results
+        (search_result, result_to_html_string(search_result)) for search_result in search_results
     ]

--- a/movielog/exports/json_collection.py
+++ b/movielog/exports/json_collection.py
@@ -8,4 +8,4 @@ class JsonCollection(TypedDict):
     slug: str
     titleCount: int
     reviewCount: int
-    description: str | None
+    description: str

--- a/movielog/repository/api.py
+++ b/movielog/repository/api.py
@@ -120,7 +120,7 @@ class Collection:
     name: str
     slug: str
     title_ids: set[str]
-    description: str | None
+    description: str
 
 
 @dataclass
@@ -135,7 +135,7 @@ def _hydrate_collection(
         name=json_collection["name"],
         slug=json_collection["slug"],
         title_ids={title["imdbId"] for title in json_collection["titles"]},
-        description=json_collection.get("description", None),
+        description=json_collection["description"],
     )
 
 
@@ -337,8 +337,8 @@ def create_or_update_review(
     )
 
 
-def new_collection(name: str) -> Collection:
-    return _hydrate_collection(json_collections.create(name))
+def new_collection(name: str, description: str) -> Collection:
+    return _hydrate_collection(json_collections.create(name, description))
 
 
 def add_person_to_watchlist(

--- a/movielog/repository/cast_and_crew_validator.py
+++ b/movielog/repository/cast_and_crew_validator.py
@@ -60,9 +60,7 @@ def _add_new_cast_and_crew(
         json_cast_and_crew.serialize(new_member)
 
 
-def _rename_files_marked_for_rename(
-    files_marked_for_rename: list[tuple[Path, Path]]
-) -> None:
+def _rename_files_marked_for_rename(files_marked_for_rename: list[tuple[Path, Path]]) -> None:
     for old_file_path, new_file_path in files_marked_for_rename:
         Path.rename(old_file_path, new_file_path)
         logger.log("{0} renamed to {1}.", old_file_path, new_file_path)
@@ -74,9 +72,7 @@ def validate() -> None:
 
     for file_path in Path(json_cast_and_crew.FOLDER_NAME).glob("*.json"):
         with Path.open(file_path, "r+") as json_file:
-            json_name = cast(
-                json_cast_and_crew.JsonCastAndCrewMember, json.load(json_file)
-            )
+            json_name = cast(json_cast_and_crew.JsonCastAndCrewMember, json.load(json_file))
 
             updated_name = deepcopy(json_name)
 

--- a/movielog/repository/datasets/downloader.py
+++ b/movielog/repository/datasets/downloader.py
@@ -41,9 +41,7 @@ def get_last_modified_date(url: str) -> datetime:
             last_modified_header,
             "%a, %d %b %Y %H:%M:%S %Z",
         )
-    logger.log(
-        "Remote file {} last updated {}.", url.split("/")[-1], last_modified_date
-    )
+    logger.log("Remote file {} last updated {}.", url.split("/")[-1], last_modified_date)
     return last_modified_date
 
 

--- a/movielog/repository/db/db.py
+++ b/movielog/repository/db/db.py
@@ -50,17 +50,11 @@ def add_index(table_name: str, column: str) -> None:
 def validate_row_count(table_name: str, expected: int) -> None:
     actual = fetch_one(f"select count(*) as count from {table_name}")["count"]
     assert expected == actual
-    logger.log(
-        "Table {} contains {} rows.", table_name, format_tools.humanize_int(actual)
-    )
+    logger.log("Table {} contains {} rows.", table_name, format_tools.humanize_int(actual))
 
 
-def insert_into_table(
-    table_name: str, insert_ddl: str, rows: Sequence[Mapping[str, Any]]
-) -> None:
-    logger.log(
-        "Inserting {} rows into {}...", format_tools.humanize_int(len(rows)), table_name
-    )
+def insert_into_table(table_name: str, insert_ddl: str, rows: Sequence[Mapping[str, Any]]) -> None:
+    logger.log("Inserting {} rows into {}...", format_tools.humanize_int(len(rows)), table_name)
     execute_many(insert_ddl, rows)
 
 

--- a/movielog/repository/imdb_ratings_data_updater.py
+++ b/movielog/repository/imdb_ratings_data_updater.py
@@ -61,9 +61,7 @@ def update_for_datasets(
         and title["imdb_votes"] >= average_imdb_votes
     )
 
-    reviewed_title_ids = {
-        review.yaml["imdb_id"] for review in markdown_reviews.read_all()
-    }
+    reviewed_title_ids = {review.yaml["imdb_id"] for review in markdown_reviews.read_all()}
 
     titles = {}
 

--- a/movielog/repository/json_cast_and_crew.py
+++ b/movielog/repository/json_cast_and_crew.py
@@ -35,9 +35,7 @@ def serialize(json_name: JsonCastAndCrewMember) -> None:
     path_tools.ensure_file_path(file_path)
 
     with Path.open(file_path, "w", encoding="utf8") as output_file:
-        output_file.write(
-            json.dumps(json_name, default=str, indent=2, ensure_ascii=False)
-        )
+        output_file.write(json.dumps(json_name, default=str, indent=2, ensure_ascii=False))
 
     logger.log(
         "Wrote {}.",

--- a/movielog/repository/json_collections.py
+++ b/movielog/repository/json_collections.py
@@ -15,28 +15,22 @@ class JsonCollection(TypedDict):
     name: str
     slug: str
     titles: list[JsonTitle]
-    description: str | None
+    description: str
 
 
-def create(name: str) -> JsonCollection:
+def create(name: str, description: str) -> JsonCollection:
     new_collection_slug = _generate_collection_slug(name)
 
     existing_collection = next(
-        (
-            collection
-            for collection in read_all()
-            if collection["slug"] == new_collection_slug
-        ),
+        (collection for collection in read_all() if collection["slug"] == new_collection_slug),
         None,
     )
 
     if existing_collection:
-        raise ValueError(
-            f'Collection with slug "{new_collection_slug}" already exists.'
-        )
+        raise ValueError(f'Collection with slug "{new_collection_slug}" already exists.')
 
     json_collection = JsonCollection(
-        name=name, slug=new_collection_slug, titles=[], description=None
+        name=name, slug=new_collection_slug, titles=[], description=description
     )
     serialize(json_collection)
     return json_collection
@@ -79,9 +73,7 @@ def serialize(json_name: JsonCollection) -> None:
     path_tools.ensure_file_path(file_path)
 
     with Path.open(file_path, "w", encoding="utf8") as output_file:
-        output_file.write(
-            json.dumps(json_name, default=str, indent=2, ensure_ascii=False)
-        )
+        output_file.write(json.dumps(json_name, default=str, indent=2, ensure_ascii=False))
 
     logger.log(
         "Wrote {}.",

--- a/movielog/repository/json_titles.py
+++ b/movielog/repository/json_titles.py
@@ -63,9 +63,7 @@ def generate_title_slug(title: str, year: str) -> str:
 
 def generate_file_path(json_title: JsonTitle) -> Path:
     if not json_title["slug"]:
-        json_title["slug"] = generate_title_slug(
-            json_title["title"], json_title["year"]
-        )
+        json_title["slug"] = generate_title_slug(json_title["title"], json_title["year"])
 
     file_name = "{}-{}.json".format(json_title["slug"], json_title["imdbId"][2:])
     return Path(FOLDER_NAME) / file_name
@@ -76,9 +74,7 @@ def serialize(json_title: JsonTitle) -> None:
     path_tools.ensure_file_path(file_path)
 
     with Path.open(file_path, "w", encoding="utf8") as output_file:
-        output_file.write(
-            json.dumps(json_title, default=str, indent=2, ensure_ascii=False)
-        )
+        output_file.write(json.dumps(json_title, default=str, indent=2, ensure_ascii=False))
 
     logger.log(
         "Wrote {}.",

--- a/movielog/repository/json_watchlist_people.py
+++ b/movielog/repository/json_watchlist_people.py
@@ -36,9 +36,7 @@ def create(watchlist: Kind, imdb_id: str, name: str) -> JsonWatchlistPerson:
     )
 
     if existing_person:
-        raise ValueError(
-            f'Person in "{watchlist}" with slug "{new_person_slug}" already exists.'
-        )
+        raise ValueError(f'Person in "{watchlist}" with slug "{new_person_slug}" already exists.')
 
     json_watchlist_person = JsonWatchlistPerson(
         imdbId=imdb_id, name=name, slug=new_person_slug, titles=[], excludedTitles=[]

--- a/movielog/repository/title_data_validator.py
+++ b/movielog/repository/title_data_validator.py
@@ -35,17 +35,13 @@ def _get_valid_title_ids() -> set[str]:
 
     for kind in json_watchlist_people.KINDS:
         for json_watchlist_person in json_watchlist_people.read_all(kind):
-            title_ids = title_ids + [
-                title["imdbId"] for title in json_watchlist_person["titles"]
-            ]
+            title_ids = title_ids + [title["imdbId"] for title in json_watchlist_person["titles"]]
 
     return set(title_ids)
 
 
 def validate_sort_title(json_title: json_titles.JsonTitle) -> None:
-    correct_sort_title = json_titles.generate_sort_title(
-        json_title["title"], json_title["year"]
-    )
+    correct_sort_title = json_titles.generate_sort_title(json_title["title"], json_title["year"])
 
     existing_sort_title = json_title["sortTitle"]
 
@@ -64,9 +60,7 @@ def validate_sort_title(json_title: json_titles.JsonTitle) -> None:
 
 
 def validate_slug(json_title: json_titles.JsonTitle, review_ids: set[str]) -> None:
-    correct_slug = json_titles.generate_title_slug(
-        json_title["title"], json_title["year"]
-    )
+    correct_slug = json_titles.generate_title_slug(json_title["title"], json_title["year"])
 
     existing_slug = json_title["slug"]
 
@@ -138,9 +132,7 @@ def removed_files_marked_for_removal(files_marked_for_removal: list[Path]) -> No
         )
 
 
-def rename_files_marked_for_rename(
-    files_marked_for_rename: list[tuple[Path, Path]]
-) -> None:
+def rename_files_marked_for_rename(files_marked_for_rename: list[tuple[Path, Path]]) -> None:
     for old_file_path, new_file_path in files_marked_for_rename:
         Path.rename(old_file_path, new_file_path)
         logger.log("{0} renamed to {1}.", old_file_path, new_file_path)

--- a/movielog/repository/watchlist_serializer.py
+++ b/movielog/repository/watchlist_serializer.py
@@ -20,16 +20,12 @@ def serialize(
     watchlist_entity: WatchlistEntity,
     folder_name: str,
 ) -> Path:
-    file_path = (
-        Path(FOLDER_NAME) / folder_name / "{}.json".format(watchlist_entity["slug"])
-    )
+    file_path = Path(FOLDER_NAME) / folder_name / "{}.json".format(watchlist_entity["slug"])
 
     path_tools.ensure_file_path(file_path)
 
     with Path.open(file_path, "w", encoding="utf8") as output_file:
-        output_file.write(
-            json.dumps(watchlist_entity, default=str, indent=2, ensure_ascii=False)
-        )
+        output_file.write(json.dumps(watchlist_entity, default=str, indent=2, ensure_ascii=False))
 
     logger.log("Wrote {}", file_path)
 

--- a/scripts/add_legacy_reviews.py
+++ b/scripts/add_legacy_reviews.py
@@ -58,9 +58,7 @@ def _generate_file_path(slug: str) -> Path:
     return file_path
 
 
-def create_review(
-    slug: str, date: datetime.date, review_content: str, grade: str
-) -> Path:
+def create_review(slug: str, date: datetime.date, review_content: str, grade: str) -> Path:
     yaml.add_representer(type(None), _represent_none)
 
     file_path = _generate_file_path(slug)
@@ -93,9 +91,7 @@ def create_review(
 def add_legacy_reviews() -> None:  # noqa: C901
     logger.log("Initializing...")
 
-    reviews = list_tools.list_to_dict(
-        repository_api.reviews(), key=lambda review: review.slug
-    )
+    reviews = list_tools.list_to_dict(repository_api.reviews(), key=lambda review: review.slug)
 
     for review_row in get_review_rows():
         viewing_dates = []

--- a/scripts/add_legacy_viewings.py
+++ b/scripts/add_legacy_viewings.py
@@ -70,9 +70,7 @@ def fetch_all(query: str, row_factory: RowFactory = sqlite3.Row) -> list[Any]:
 def add_legacy_viewings() -> None:  # noqa: C901
     logger.log("Initializing...")
 
-    reviews = list_tools.list_to_dict(
-        repository_api.reviews(), key=lambda review: review.slug
-    )
+    reviews = list_tools.list_to_dict(repository_api.reviews(), key=lambda review: review.slug)
 
     for post_id_row in get_post_ids():
         viewing_dates = [
@@ -83,9 +81,7 @@ def add_legacy_viewings() -> None:  # noqa: C901
 
         if len(viewing_dates) == 0:
             raise Exception(  # noqa: TRY002
-                "No viewings for {} [{}]".format(
-                    post_id_row["post_name"], post_id_row["ID"]
-                )
+                "No viewings for {} [{}]".format(post_id_row["post_name"], post_id_row["ID"])
             )
 
         slug = post_id_row["post_name"]

--- a/tests/cli/test_new_collection.py
+++ b/tests/cli/test_new_collection.py
@@ -14,10 +14,10 @@ def mock_new_collection(mocker: MockerFixture) -> MagicMock:
 
 
 def test_calls_add_collection(mock_input: MockInput, mock_new_collection: MagicMock) -> None:
-    mock_input(["Halloween", Enter, "y"])
+    mock_input(["Halloween", Enter, "y", "A horror movie franchise", Enter])
     new_collection.prompt()
 
-    mock_new_collection.assert_called_once_with("Halloween")
+    mock_new_collection.assert_called_once_with("Halloween", "A horror movie franchise")
 
 
 def test_does_not_call_add_viewing_if_no_movie(

--- a/tests/repository/datasets/test_downloader.py
+++ b/tests/repository/datasets/test_downloader.py
@@ -9,16 +9,12 @@ from movielog.repository.datasets import downloader
 
 @pytest.fixture(autouse=True)
 def subprocess_mock(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch(
-        "movielog.repository.datasets.downloader.subprocess.check_output"
-    )
+    return mocker.patch("movielog.repository.datasets.downloader.subprocess.check_output")
 
 
 @pytest.fixture(autouse=True)
 def request_mock(mocker: MockerFixture) -> MagicMock:
-    url_open_mock = mocker.patch(
-        "movielog.repository.datasets.downloader.request.urlopen"
-    )
+    url_open_mock = mocker.patch("movielog.repository.datasets.downloader.request.urlopen")
 
     magic_method_mock = url_open_mock.return_value.__enter__
 


### PR DESCRIPTION
## Summary
- Makes the `description` field required for collections throughout the application
- Updates CLI to prompt for description when creating new collections
- Ensures data consistency by requiring meaningful descriptions for all collections

## Changes
- Updated `JsonCollection` TypedDict to make `description` a required `str` field
- Modified `create()` function to accept a `description` parameter
- Updated CLI to prompt for description after confirming collection name
- Updated all related type definitions and functions to handle required descriptions
- Applied ruff formatting to maintain code consistency

## Test plan
- [x] Run `uv run pytest` - all tests pass
- [x] Run `uv run mypy .` - no type errors
- [x] Run `uv run ruff check .` - all checks pass
- [x] Run `uv run ruff format --check .` - code is properly formatted
- [x] Run `npm run format` - prettier formatting check passes
- [x] Updated tests to include description in test data

🤖 Generated with [Claude Code](https://claude.ai/code)