### PR TITLE
Fix missing validation for viewing medium/venue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ export_data()
    uv run ruff format --check .
    uv run mypy .
    uv run pytest
-   npm run prettier:check  # or the appropriate prettier command
+   npm run format  # checks prettier formatting
    ```
 
 3. **Fix any issues** found by the checks before proceeding with the PR

--- a/movielog/repository/markdown_viewings.py
+++ b/movielog/repository/markdown_viewings.py
@@ -38,7 +38,7 @@ def create(
     venue: str | None,
     medium_notes: str | None,
 ) -> MarkdownViewing:
-    # assert medium or venue
+    assert medium or venue
 
     markdown_viewing = MarkdownViewing(
         sequence=_next_sequence_for_date(date),


### PR DESCRIPTION
## Summary
- Restored validation to ensure viewings have either a medium or venue specified
- Updated CLAUDE.md with correct npm script name for prettier checks

## Test plan
- [x] All tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run mypy .`)
- [x] Code formatting verified (`uv run ruff format --check .`)
- [x] Prettier formatting verified (`npm run format`)

🤖 Generated with [Claude Code](https://claude.ai/code)