### PR TITLE
Fix typo: change 'inherit' to 'inherent' in Scarface review

### DIFF
--- a/reviews/scarface-1932.md
+++ b/reviews/scarface-1932.md
@@ -14,4 +14,4 @@ You know the story beats. The <span data-imdb="tt0086250">remake</span> retains 
 
 Sure, the comedy bits involving Vince Barnett as Muni's dim-witted secretary fall flat. And Ann Dvorak's wide-eyed emoting pales next to Muni's ice-cold mania. But I can forgive these missteps.
 
-I'm less forgiving of the Universal Studios Blu-ray transfer. Perhaps its inherit in the source, but many scenes exhibit a soft focus blur that resembles an upscale. Disappointing.
+I'm less forgiving of the Universal Studios Blu-ray transfer. Perhaps its inherent in the source, but many scenes exhibit a soft focus blur that resembles an upscale. Disappointing.


### PR DESCRIPTION
## Summary
- Fixed spelling error where 'inherit' should be 'inherent' in Scarface (1932) review
- Corrected phrase about video transfer quality issues being inherent in the source

## Test plan
- [x] All linting checks pass
- [x] All tests pass
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.ai/code)