### PR TITLE
Fix typo: change 'inherit' to 'inherent' in Cure review

### DIFF
--- a/reviews/cure-1997.md
+++ b/reviews/cure-1997.md
@@ -23,7 +23,7 @@ By the time Takabe sets out in pursuit of the escaped Mamiya, we're unsure if wh
 
 Like the best of David Lynch's films, it invites rewatches to uncover its mysteries. Like the worst of David Lynch's films, it has no definitive solution to be found.
 
-As a quasi-remake of <span data-imdb-id="tt0075930">_God Told Me To_</span>, the film improves on the original by focusing on the police procedural elements exploring the horror inherit in otherwise sane people committing unexplained acts of hideous violence.
+As a quasi-remake of <span data-imdb-id="tt0075930">_God Told Me To_</span>, the film improves on the original by focusing on the police procedural elements exploring the horror inherent in otherwise sane people committing unexplained acts of hideous violence.
 
 But like _God Told Me To_, _Cure_ struggles with the payoff. Positing Mamiya as “a missionary sent to propagate the ceremony” proves full of possibility, but Kurosawa's decision to tie this to Franz Mesmer disappoints. Mesmer and his animal magnetism theories don't inspire fear or even curiosity.
 


### PR DESCRIPTION
## Summary
- Fixed spelling error where 'inherit' should be 'inherent' in Cure (1997) review
- Corrected phrase about the horror inherent in sane people committing acts of violence

## Test plan
- [x] All linting checks pass
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.ai/code)