### PR TITLE
Fix typos: change 'it's' to 'its' and 'inherit' to 'inherent' in Made review

### DIFF
--- a/reviews/made-2001.md
+++ b/reviews/made-2001.md
@@ -13,4 +13,4 @@ The problems start with Favreau's script. The characters he crafts for himself a
 
 Next there's Favreau the director. He seems to allow Vaughn a good bit of leeway to improvise and while this does lead to some of the film's funniest bits, it just as often feels forced or even lazy. A little bit of tightening would have gone a long way.
 
-Ultimately, _Made_ is a disappointment given the quality of work the talent involved has shown both before the film and since. Perhaps Favreau and Vaughn were a bit too comfortable with each other, or perhaps they were too close to the material to see it's inherit weakness, but whatever the reason, you're better off re-watching _Swingers_ instead.
+Ultimately, _Made_ is a disappointment given the quality of work the talent involved has shown both before the film and since. Perhaps Favreau and Vaughn were a bit too comfortable with each other, or perhaps they were too close to the material to see its inherent weakness, but whatever the reason, you're better off re-watching _Swingers_ instead.


### PR DESCRIPTION
## Summary
- Fixed spelling errors in Made (2001) review:
  - Changed 'it's inherit' to 'its inherent'
  - Corrected possessive pronoun and adjective usage

## Test plan
- [x] All linting checks pass
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.ai/code)