### PR TITLE
fix: correct spelling in The Dirty Dozen review

### DIFF
--- a/reviews/the-dirty-dozen-1967.md
+++ b/reviews/the-dirty-dozen-1967.md
@@ -13,4 +13,4 @@ This machismo extends to every aspect of the film, including it's cast. Here _Th
 
 And tough they are. While the entire film is perfectly cast, Marvin and Bronson especially seem born to play their respective roles. Telly Savalas also delivers a truly frightening performance that will stay with you long after the film is over.
 
-_The Dirty Dozen_ has its flaws. With 13 characters some are bound to be underdeveloped, and at times we loose track of where everyone is. Also at 145 minutes the movie does come in a little long. The finale will make you forget these minor quibbles though, as it's one of the best action sequences ever.
+_The Dirty Dozen_ has its flaws. With 13 characters some are bound to be underdeveloped, and at times we lose track of where everyone is. Also at 145 minutes the movie does come in a little long. The finale will make you forget these minor quibbles though, as it's one of the best action sequences ever.


### PR DESCRIPTION
## Summary
- Fixed spelling error: changed "loose" to "lose" in line 16

## Test plan
- [x] Run all linting and formatting checks
- [x] Review the change for correctness

🤖 Generated with [Claude Code](https://claude.ai/code)