### PR TITLE
fix: correct word usage in Dead Heat on a Merry-Go-Round review

### DIFF
--- a/reviews/dead-heat-on-a-merry-go-round-1966.md
+++ b/reviews/dead-heat-on-a-merry-go-round-1966.md
@@ -7,7 +7,7 @@ slug: dead-heat-on-a-merry-go-round-1966
 
 A con man (James Coburn) stages an airport bank robbery to coincide with the arrival of the Soviet Premier.
 
-_Dead Heat on a Merry-Go-Round_ is notable chiefly as the first screen appearance of Harrison Ford (he has a single scene as a page-boy), but the movie itself is also an uber-cool crime caper in the Elmore Leonard vain that's quite enjoyable thanks to the combination of the script by director Bernard Girard and the immense charisma of lead James Coburn.
+_Dead Heat on a Merry-Go-Round_ is notable chiefly as the first screen appearance of Harrison Ford (he has a single scene as a page-boy), but the movie itself is also an uber-cool crime caper in the Elmore Leonard vein that's quite enjoyable thanks to the combination of the script by director Bernard Girard and the immense charisma of lead James Coburn.
 
 Girard's script is a con-job unto itself in that we never learn anything "real" about Coburn's character, only the identities he assumes as he finances and eventually executes his heist. From the opening scene, he's on the clock, working a prison psychologist in order to qualify for early parole. It's a clever conceit that's easy to screw up, but Girard and Coburn handle it well.
 


### PR DESCRIPTION
## Summary
- Fixed word usage: changed "vain" to "vein" in line 10

## Test plan
- [x] Run all linting and formatting checks
- [x] Review the change for correctness

🤖 Generated with [Claude Code](https://claude.ai/code)