### PR TITLE
fix: correct apostrophe usage in Mr. Smith Goes to Washington review

### DIFF
--- a/reviews/mr-smith-goes-to-washington-1939.md
+++ b/reviews/mr-smith-goes-to-washington-1939.md
@@ -9,6 +9,6 @@ Jimmy Stewart's terrific performance makes up for some overhanded direction by F
 
 This is a black and white movie. I mean that in both the literally and metaphorically. Literally because it was shot on black and white film. Metaphorically because everything in the movie is either right or wrong.
 
-This clear division is both the movie's greatest strength and it's greatest weakness. It polarizes the characters motives and puts the audience firmly behind Jimmy Stewart's Jefferson Smith, but at the same time hurts the movie's credibility by refusing to acknowledge any shades of gray.
+This clear division is both the movie's greatest strength and its greatest weakness. It polarizes the characters motives and puts the audience firmly behind Jimmy Stewart's Jefferson Smith, but at the same time hurts the movie's credibility by refusing to acknowledge any shades of gray.
 
 Director Frank Capra uses every trick in the book to pull the viewer's emotion, but they only work because Jimmy Stewart's perfect performance makes you oblivious to them. By the end of the film you _believe_ in Jefferson Smith, and that belief is a testament to the talent of Jimmy Stewart.


### PR DESCRIPTION
## Summary
- Fixed apostrophe: changed "it's" to "its" (possessive) in line 12

## Test plan
- [x] Run all linting and formatting checks
- [x] Review the change for correctness

🤖 Generated with [Claude Code](https://claude.ai/code)