### PR TITLE
fix: use American spelling of judgment in X review

### DIFF
--- a/reviews/x-2022.md
+++ b/reviews/x-2022.md
@@ -10,7 +10,7 @@ In 1979, a group of amateur filmmakers travels to a remote Texas farm to film an
 
 <!-- end -->
 
-What if the characters from <span data-imdb-id="tt0118749">_Boogie Nights_</span> wandered into <span data-imdb-id="tt0072271">_The Texas Chain Saw Massacre_</span>? Writer-director Ti West evokes the same bleak, rural atmosphere as Tobe Hooper's classic, and regards his characters with the same caring, judgement-free eye as Paul Thomas Anderson. The first act overflows with atmosphere and potential.
+What if the characters from <span data-imdb-id="tt0118749">_Boogie Nights_</span> wandered into <span data-imdb-id="tt0072271">_The Texas Chain Saw Massacre_</span>? Writer-director Ti West evokes the same bleak, rural atmosphere as Tobe Hooper's classic, and regards his characters with the same caring, judgment-free eye as Paul Thomas Anderson. The first act overflows with atmosphere and potential.
 
 But this proves a feint. West's true intent lies in contrasting Maxine, the young, fame-hungry would-be adult film starlet, with Pearl, the elderly wife of the farm's owner. Mia Goth plays both parts.
 


### PR DESCRIPTION
## Summary
- Fixed spelling: changed "judgement-free" to "judgment-free" in line 13 for consistency with American spelling

## Test plan
- [x] Run all linting and formatting checks
- [x] Review the change for correctness

🤖 Generated with [Claude Code](https://claude.ai/code)