### PR TITLE
Fix spelling and grammar errors in reviews

### DIFF
--- a/reviews/a-nightmare-on-elm-street-2-freddys-revenge-1985.md
+++ b/reviews/a-nightmare-on-elm-street-2-freddys-revenge-1985.md
@@ -41,6 +41,6 @@ Sholder also bears responsibility for casting Mark Patton as Jesse and crafting 
 
 The sequel's lone bright spot lies in the Freddy makeup, which shines, as illustrated by an early sequence between Freddy and Jesse. "You've got the body," Freddy says to Jesse as he removes his hat and peels the skin off the top of his skull, "and I've got the brain." A clever way of explaining possession that proves to be the film's singular memorable sequence.
 
-Fortunately, both Shaye and Shoulder would course correct. Shaye would pivot back to Craven’s original premise with the franchise’s <span data-imdb-id="tt0093629">third installment</span>, and Sholder would next direct <span data-imdb-id="tt0093185">_The Hidden_</span>.
+Fortunately, both Shaye and Sholder would course correct. Shaye would pivot back to Craven’s original premise with the franchise’s <span data-imdb-id="tt0093629">third installment</span>, and Sholder would next direct <span data-imdb-id="tt0093185">_The Hidden_</span>.
 
 [^1]: _Heroes and Villains_, _A Nightmare on Elm Street Collection_, Warner Bros., 2013

--- a/reviews/aqua-teen-forever-plantasm-2022.md
+++ b/reviews/aqua-teen-forever-plantasm-2022.md
@@ -41,4 +41,4 @@ Like the original series, the absurdist humor hits-and-misses. The longer runnin
 
 “Big-time!” says Err.
 
-Series fans should enjoy it, but it won’t make any new converts. Indeed, it’s telling that a gag that would have eliminated the entire third act elicited big laughs, hinting that perhaps—even and only seventy-six minutes—this entry runs too long.
+Series fans should enjoy it, but it won’t make any new converts. Indeed, it's telling that a gag that would have eliminated the entire third act elicited big laughs, hinting that perhaps—even at only seventy-six minutes—this entry runs too long.

--- a/reviews/avengers-age-of-ultron-2015.md
+++ b/reviews/avengers-age-of-ultron-2015.md
@@ -6,4 +6,4 @@ grade: C+
 slug: avengers-age-of-ultron-2015
 ---
 
-With the _Infinity Saga_ done, it’s easier to forgive this entry for what it is: a plot-heavy middle chapter in a larger story that regulates the Ultron character to a McGuffin.
+With the _Infinity Saga_ done, it's easier to forgive this entry for what it is: a plot-heavy middle chapter in a larger story that relegates the Ultron character to a McGuffin.


### PR DESCRIPTION
## Summary
- Fixed 3 spelling and grammar errors found in movie reviews
- Corrected director name, word choice, and awkward phrasing

## Changes
- **a-nightmare-on-elm-street-2-freddys-revenge-1985.md**: Fixed "Shoulder" → "Sholder" (correct spelling of director Jack Sholder's name)
- **aqua-teen-forever-plantasm-2022.md**: Fixed awkward phrasing "even and only seventy-six minutes" → "even at only seventy-six minutes"
- **avengers-age-of-ultron-2015.md**: Fixed incorrect word "regulates" → "relegates" (correct word choice for the context)

## Test plan
- [x] Verified spelling corrections are accurate
- [x] Confirmed grammar improvements maintain original meaning
- [x] Reviews remain properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)