### PR TITLE
Fix typos in movie reviews

### DIFF
--- a/reviews/casino-royale-2006.md
+++ b/reviews/casino-royale-2006.md
@@ -14,7 +14,7 @@ After <a href="https://www.franksbooklog.com/reviews/casino-royale-by-ian-flemin
 
 The book more-or-less starts with Bond arriving at the casino on orders from MI6. The film introduces a whole backstory that sees Bond himself discover Le Chiffre. It doesn't arrive at the titular casino until the half-way point. On the plus side, this provides several entertaining set-pieces, including an early parkour chase that announces this Bond as an action hero. On the down side, it stretches the film past two hours.
 
-Now that we're at the casino, the film fumbles one of the novel's best beats by turning Felix Lighter's introduction into a big reveal. That said, I loved the change from baccarat to poker, and the assassination attempt from shooting to poisoning. Both plausible changes.
+Now that we're at the casino, the film fumbles one of the novel's best beats by turning Felix Leiter's introduction into a big reveal. That said, I loved the change from baccarat to poker, and the assassination attempt from shooting to poisoning. Both plausible changes.
 
 Less plausible changes include the probability-focused Le Chiffre shorting an aerospace manufacturer as part of a complicated bomb plot. Or using Vesper as a roadblock instead of spikes. Or why the winnings had to be deposited and withdrawn. Or why Le Chiffre would implicate Mathis.
 

--- a/reviews/deathtrap-1982.md
+++ b/reviews/deathtrap-1982.md
@@ -17,7 +17,7 @@ That's the movie. It's told us what's coming and yet we're still surprised.
 
 The trick works because of the film's delightful dialog. The script proves self-aware, as evidenced by Caine's early comment on his trip out of New York City:
 
-> Do you know what happened to me tonight? I passed out in the train, and i came to in the terminus at Montauk! End of the line! Bloody symbolic.
+> Do you know what happened to me tonight? I passed out in the train, and I came to in the terminus at Montauk! End of the line! Bloody symbolic.
 
 These call-outs build credibility, allowing the film to afford Caine cynical quips like “Nothing recedes like success,” without feeling pretentious.
 


### PR DESCRIPTION
## Summary
- Fixed capitalization error in deathtrap-1982.md review (lowercase 'i' changed to 'I')
- Fixed character name spelling in casino-royale-2006.md review (Felix Lighter corrected to Felix Leiter)

## Test plan
- [x] Verified correct spelling of Felix Leiter (James Bond character)
- [x] Verified proper capitalization of pronoun 'I'
- [x] Checked for any other similar issues across all 1,801 review files

🤖 Generated with [Claude Code](https://claude.ai/code)