### PR TITLE
fix: correct spelling of 'led' in 21-2008.md review

### DIFF
--- a/reviews/21-2008.md
+++ b/reviews/21-2008.md
@@ -5,7 +5,7 @@ grade: C-
 slug: 21-2008
 ---
 
-An MIT student joins a card-counting team lead by a professor (Kevin Spacey) only to run up against a casino security manager (Laurence Fishburne).
+An MIT student joins a card-counting team led by a professor (Kevin Spacey) only to run up against a casino security manager (Laurence Fishburne).
 
 _21_ is basically a heist film buried in useless sub-plots. There’s about 90 minutes of movie here but, unfortunately, the film runs a little over two hours.
 


### PR DESCRIPTION
## Summary
- Fixed spelling error: changed "lead" to "led" in the phrase "card-counting team led by a professor"

## Test plan
- [x] Verified the spelling correction in the review file
- [x] Confirmed no other instances of this error pattern exist

🤖 Generated with [Claude Code](https://claude.ai/code)