### PR TITLE
Fix grammar error in Stalag 17 review

### DIFF
--- a/reviews/stalag-17-1953.md
+++ b/reviews/stalag-17-1953.md
@@ -5,7 +5,7 @@ grade: B-
 slug: stalag-17-1953
 ---
 
-_Stalag 17_ is a somewhat uneven mix of comedy and drama that hits more often then it misses.
+_Stalag 17_ is a somewhat uneven mix of comedy and drama that hits more often than it misses.
 
 Set during World War II, William Holden is terrific in his Oscar winning role as a cynical soldier who wheels and deals his way into as comfortable a life as possible in a German prison camp. His part makes the movie worthwhile as it manages to compensate for some of the stilted humor.
 


### PR DESCRIPTION
## Summary
- Fixed a then/than grammar error in the Stalag 17 (1953) review
- Changed "hits more often then it misses" to "hits more often than it misses"

## Test plan
- [x] Verified the correction is grammatically correct
- [x] Checked that no other similar errors exist in the file

🤖 Generated with [Claude Code](https://claude.ai/code)