### PR TITLE
Fix spelling and grammar errors in movie reviews

### DIFF
--- a/reviews/fight-club-1999.md
+++ b/reviews/fight-club-1999.md
@@ -9,7 +9,7 @@ Disillusioned with his life, a young professional (Edward Norton) befriends a st
 
 _Fight Club_ has style. The opening scene, which flows seamlessly from the credits, has some great special effects, creative editing, and flashy cinematography. All that and you're barely five minutes into the movie.
 
-The thing is though, it works. All the tricks and the effects, they all work _for_ the story, and never against it. Director David Fincher is like a professional athlete using every move in his arsenal to help his team score. That may be one of the worst analogies ever, but looking at the way everything in _Fight Club_ comes together, its hard to ignore.
+The thing is though, it works. All the tricks and the effects, they all work _for_ the story, and never against it. Director David Fincher is like a professional athlete using every move in his arsenal to help his team score. That may be one of the worst analogies ever, but looking at the way everything in _Fight Club_ comes together, it's hard to ignore.
 
 Say what you will about Brad Pitt's acting in other films, but he works here. His Tyler Durden is so perfectly realized it's hard to believe writer Chuck Palahniuk didn't have him in mind when he wrote the book. Combine this with the always excellent Edward Norton and the acting alone makes this movie impressive.
 

--- a/reviews/freaks-1932.md
+++ b/reviews/freaks-1932.md
@@ -10,4 +10,4 @@ Though shot with actual carnival performers, Freaks features no carnival perform
 
 <!-- end -->
 
-Midway through, the film presents a title card signalling a tonal shift. What seemed welcoming becomes ominous. The performers band together to exact revenge in an underplayed sequence full of dread. I loved everything until the coda's final reveal, which felt incongruous with the film's verisimilitude.
+Midway through, the film presents a title card signaling a tonal shift. What seemed welcoming becomes ominous. The performers band together to exact revenge in an underplayed sequence full of dread. I loved everything until the coda's final reveal, which felt incongruous with the film's verisimilitude.

--- a/reviews/psycho-1960.md
+++ b/reviews/psycho-1960.md
@@ -9,7 +9,7 @@ A young woman (Janet Leigh), on the run after stealing a large sum of money from
 
 _Psycho_, for better or worse, ushered in the modern horror film. The monster wasn't easily dismissed as supernatural, easily recognized as Karloff in make-up or Lugosi in a cape; no, in _Psycho_ the monster was the quiet boy next door, who never harmed a fly.
 
-Anthony Perkins is terrific, managing to be both boyishly charming and sinister at the same time. His performance ranks as one of the screen's best villains, and set the standard for many knock-off's to come.
+Anthony Perkins is terrific, managing to be both boyishly charming and sinister at the same time. His performance ranks as one of the screen's best villains, and set the standard for many knock-offs to come.
 
 Putting aside the famous shower sequence, which still holds up nearly 50 years later thanks to some great editing and sound effects, _Psycho_ remains a gripping thriller that works largely because it's so well put together.
 

--- a/reviews/the-thing-1982.md
+++ b/reviews/the-thing-1982.md
@@ -15,4 +15,4 @@ The special effects are gruesomely inventive. We see one character defibrillatin
 
 Yet, the movie isn’t just about the monster. There’s a very Hawks-ian feel to the characters and their fragile camaraderie, that, along with the desolate location photography and weathered set design, earns our buy-in right away.
 
-While there’s no way of knowing how Hawks would have reacted to the amped up gore, he certainly would have appreciated the Carpenter’s unsentimental approach to capturing the men’s working lives and relationships with one-another, as well as the honest ending.
+While there's no way of knowing how Hawks would have reacted to the amped up gore, he certainly would have appreciated Carpenter's unsentimental approach to capturing the men's working lives and relationships with one-another, as well as the honest ending.

--- a/reviews/vertigo-1958.md
+++ b/reviews/vertigo-1958.md
@@ -5,7 +5,7 @@ grade: B+
 slug: vertigo-1958
 ---
 
-In director Alfred Hitchock's seminal mystery, James Stewart plays John "Scottie" Ferguson, a former San Francisco detective who left the force feeling that his latent acrophobia played a part in the death of a fellow officer.
+In director Alfred Hitchcock's seminal mystery, James Stewart plays John "Scottie" Ferguson, a former San Francisco detective who left the force feeling that his latent acrophobia played a part in the death of a fellow officer.
 
 An old acquaintance asks Scottie to shadow his heiress wife Madeline (Kim Novak), whose shipping company he runs, explaining that she believes herself to be possessed and that he fears she may be suicidal.
 


### PR DESCRIPTION
## Summary
- Fixed 5 spelling and grammar errors found in movie review files
- Corrected apostrophe usage, spelling mistakes, and American vs British spelling

## Changes
- Fixed "the Carpenter's" to "Carpenter's" in `the-thing-1982.md` 
- Changed "knock-off's" to "knock-offs" in `psycho-1960.md`
- Corrected "Hitchock" to "Hitchcock" in `vertigo-1958.md`
- Changed British "signalling" to American "signaling" in `freaks-1932.md`
- Added missing apostrophe "its" to "it's" in `fight-club-1999.md`

## Test plan
- [x] Reviewed all changes for correctness
- [x] Ensured consistent American English spelling throughout

🤖 Generated with [Claude Code](https://claude.ai/code)