### PR TITLE
fix: correct spelling and grammar errors in viewing files

### DIFF
--- a/viewings/2012-04-27-01-the-big-sleep-1946.md
+++ b/viewings/2012-04-27-01-the-big-sleep-1946.md
@@ -11,4 +11,4 @@ mediumNotes: null
 
 Hawks's original cut, shown overseas to American servicemen but never released theatrically, is a good first draft, but there's a lot of fat. The scene of Bogart searching Geiger's apartment and the very talky plot recap in the DA's office after Bogart snares Lundgren, amount to dead air.
 
-And the decision to dress Bacall in veil for one of her few scenes with Bogart is a head scratcher. Watch the theatrical cut instead.
+And the decision to dress Bacall in a veil for one of her few scenes with Bogart is a head scratcher. Watch the theatrical cut instead.

--- a/viewings/2021-09-20-01-good-times-1967.md
+++ b/viewings/2021-09-20-01-good-times-1967.md
@@ -6,6 +6,6 @@ slug: good-times-1967
 venue: null
 venueNotes: null
 medium: Blu-ray
-mediumNotes: Kino Lober, 2018
+mediumNotes: Kino Lorber, 2018
 ---
 

--- a/viewings/2022-05-29-01-event-horizon-1997.md
+++ b/viewings/2022-05-29-01-event-horizon-1997.md
@@ -11,8 +11,8 @@ mediumNotes: null
 
 After two years of pandemic avoidance, I returned to the cinema. The Prince Charles welcomed me back with a red carpet.
 
-Okay, so it was for a premier later that evening, but still…
+Okay, so it was for a premiere later that evening, but still…
 
 The movie played better a second time. The piercing volume and larger screen made for more immersive atmosphere, while the 35mm projection better masked the optical effects.
 
-It's still frustrating how close it comes to greatness, but it proves a solid B-Movie. Fishburn's expository dialogue still sounds tin eared and Neill's performance still shines.
+It's still frustrating how close it comes to greatness, but it proves a solid B-Movie. Fishburn's expository dialogue still sounds tin-eared and Neill's performance still shines.

--- a/viewings/2022-06-13-01-good-times-1967.md
+++ b/viewings/2022-06-13-01-good-times-1967.md
@@ -6,7 +6,7 @@ slug: good-times-1967
 venue: null
 venueNotes: null
 medium: Blu-ray
-mediumNotes: Kino Lober, 2018
+mediumNotes: Kino Lorber, 2018
 ---
 
 Commentary watch. Lee Gambin, an unabashed fan of both Friedkin and Sonny and Cher, offers a wealth of information about the film's production and stars. But he did little to convince me of the film's merits. At best, I gained an appreciation for Friedkin's dynamic camera work. But I still struggled with Bono's uncanny valley performance. He's a thirty-something man acting like a teenager.

--- a/viewings/2025-01-11-02-the-return-of-the-musketeers-1989.md
+++ b/viewings/2025-01-11-02-the-return-of-the-musketeers-1989.md
@@ -6,6 +6,6 @@ slug: the-return-of-the-musketeers-1989
 medium: Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: Kino Lober, 2020
+mediumNotes: Kino Lorber, 2020
 ---
 

--- a/viewings/2025-02-13-02-thursday-1998.md
+++ b/viewings/2025-02-13-02-thursday-1998.md
@@ -6,6 +6,6 @@ slug: thursday-1998
 medium: Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: Kino Lober, 2021
+mediumNotes: Kino Lorber, 2021
 ---
 

--- a/viewings/2025-03-22-04-fright-night-1985.md
+++ b/viewings/2025-03-22-04-fright-night-1985.md
@@ -9,4 +9,4 @@ venueNotes: null
 mediumNotes: Sony Pictures, 2022
 ---
 
-While the 4k looks great, what should have been the definitive presentation falls short thanks to an Atmos soundtrack that buries the vocals of several songs during the club sequence. An inexplicable oversight that given the soundtrack's popularity.
+While the 4k looks great, what should have been the definitive presentation falls short thanks to an Atmos soundtrack that buries the vocals of several songs during the club sequence. An inexplicable oversight given the soundtrack's popularity.

--- a/viewings/2025-07-04-01-scream-and-scream-again-1970.md
+++ b/viewings/2025-07-04-01-scream-and-scream-again-1970.md
@@ -9,7 +9,7 @@ venueNotes: null
 mediumNotes: Kino Lorber, 2019
 ---
 
-USA cut. Inferior to the UK verison, it omits Bellaver's rock toss, and Lee's final line to Price.
+USA cut. Inferior to the UK version, it omits Bellaver's rock toss, and Lee's final line to Price.
 
 Tim Lucas delivers a comprehensive commentary in his signature warm, conversational style. He reveals fascinating connections, like how director Gordon Hessler--born in Germany but raised in England--brings subtle German cinematic influences to the film. Lucas points to an early mirror shot of a character shaving and the brassy jazz score that wouldn't be out of place in an Edgar Wallace thriller.
 

--- a/viewings/2025-07-07-01-the-return-of-the-musketeers-1989.md
+++ b/viewings/2025-07-07-01-the-return-of-the-musketeers-1989.md
@@ -6,7 +6,7 @@ slug: the-return-of-the-musketeers-1989
 medium: Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: Kino Lober, 2020
+mediumNotes: Kino Lorber, 2020
 ---
 
 Self-proclaimed "Richard Lester enthusiast" Peter Tonguette's commentary is long on hero worship, short on insight. We get complete plot summaries of <span data-imdb-id="tt0081573">_Superman II_</span> and <span data-imdb-id="tt0086393">_Superman III_</span>. We learn nothing about Oliver Reed's health problems during filming.


### PR DESCRIPTION
## Summary
- Fixed multiple spelling and grammar errors found in viewing files during comprehensive review

## Changes
- Fixed "Kino Lober" → "Kino Lorber" in 5 files
- Fixed "verison" → "version" 
- Fixed "premier" → "premiere"
- Fixed "tin eared" → "tin-eared" (compound adjective)
- Fixed grammar: removed extraneous "that" in sentence fragment
- Fixed grammar: added missing article "a" before "veil"

## Test plan
- [x] All files checked for spelling/grammar errors
- [x] Changes reviewed for accuracy
- [x] No functional changes, only typo corrections

🤖 Generated with [Claude Code](https://claude.ai/code)