### PR TITLE
fix: correct spelling and grammar errors in viewing files

### DIFF
--- a/viewings/2021-11-25-01-blood-rage-1987.md
+++ b/viewings/2021-11-25-01-blood-rage-1987.md
@@ -13,4 +13,4 @@ In a 2015 commentary, moderator Ewan Cant prompts director John Grissmer for ins
 
 John Dalley, who now co-owns the picture, offers little insight, but speaks with enthusiasm that goes beyond mere salesmanship.
 
-My most interesting take-away: producer Marianne Kanter--who plays a sanitarium doctor--mandated the nudity and violence, further diminishing Grissmer's impact.
+My most interesting takeaway: producer Marianne Kanter--who plays a sanitarium doctor--mandated the nudity and violence, further diminishing Grissmer's impact.

--- a/viewings/2024-11-07-02-chinatown-1974.md
+++ b/viewings/2024-11-07-02-chinatown-1974.md
@@ -6,6 +6,6 @@ slug: chinatown-1974
 medium: 4k UHD Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: 'Paramount Pictures, 2024 '
+mediumNotes: 'Paramount Pictures, 2024'
 ---
 

--- a/viewings/2025-01-27-01-deadly-blessing-1981.md
+++ b/viewings/2025-01-27-01-deadly-blessing-1981.md
@@ -11,7 +11,7 @@ mediumNotes: Arrow, 2017
 
 Wes Craven proves both entertaining and candid in this 2013 commentary moderated by David Gregory.
 
-The film was shot in Texas during a cold snap. Craven calls it "freezing," which makes the actors' summer clothes and one character's apparent sweating during a jogging scene all the more impressive. 
+The film was shot in Texas during a cold snap. Craven calls it "freezing," which makes the actors' summer clothes and one character's apparent sweating during a jogging scene all the more impressive.
 
 Craven praises the local Texas crew's skill and adaptability, then drops a jarring anecdote: they cheered when news of John Lennon's assassination reached the set.
 
@@ -25,5 +25,5 @@ Having been raised fundamentalist Baptist, Craven brought personal experience to
 
 Looking back, Craven views the film with clear eyes. He acknowledges the studio mandates that hampered his vision but owns his decisions without excuse-making. It's refreshing honesty from a director who could have easily blamed others.
 
-The commentary ends on a charming note: Craven apologizes for the film's ridiculous coda. After all these years, he's still embarrassed by it. 
+The commentary ends on a charming note: Craven apologizes for the film's ridiculous coda. After all these years, he's still embarrassed by it.
 

--- a/viewings/2025-02-22-01-asylum-1972.md
+++ b/viewings/2025-02-22-01-asylum-1972.md
@@ -6,6 +6,6 @@ slug: asylum-1972
 medium: Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: 'Severin Films, 2018 '
+mediumNotes: 'Severin Films, 2018'
 ---
 

--- a/viewings/2025-03-22-01-casablanca-1942.md
+++ b/viewings/2025-03-22-01-casablanca-1942.md
@@ -6,6 +6,6 @@ slug: casablanca-1942
 medium: 4k UHD Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: 'Warner Bros., 2022 '
+mediumNotes: 'Warner Bros., 2022'
 ---
 

--- a/viewings/2025-06-12-01-ebola-syndrome-1996.md
+++ b/viewings/2025-06-12-01-ebola-syndrome-1996.md
@@ -9,6 +9,6 @@ venueNotes: null
 mediumNotes: Vinegar Syndrome, 2021
 ---
 
-Samm Deighan's commentary works best as an introduction to Category III films for newcomers, providing solid context for where _Ebola Syndrome_ fits within Hong Kong's exploitation tradition. Established fans may find themselves wanting more specific production details and less general background. 
+Samm Deighan's commentary works best as an introduction to Category III films for newcomers, providing solid context for where _Ebola Syndrome_ fits within Hong Kong's exploitation tradition. Established fans may find themselves wanting more specific production details and less general background.
 
-Still, her enthusiasm is infectious and I loved how she describes Category III cinema as "very wet films." Her frequent worry about offending listeners, however, undermines her otherwise confident analysis. After all, anyone listening to a commentary on _Ebola Syndrome_ has already made peace with Category III's transgressions. 
+Still, her enthusiasm is infectious and I loved how she describes Category III cinema as "very wet films." Her frequent worry about offending listeners, however, undermines her otherwise confident analysis. After all, anyone listening to a commentary on _Ebola Syndrome_ has already made peace with Category III's transgressions.

--- a/viewings/2025-07-07-01-the-return-of-the-musketeers-1989.md
+++ b/viewings/2025-07-07-01-the-return-of-the-musketeers-1989.md
@@ -11,7 +11,7 @@ mediumNotes: Kino Lorber, 2020
 
 Self-proclaimed "Richard Lester enthusiast" Peter Tonguette's commentary is long on hero worship, short on insight. We get complete plot summaries of <span data-imdb-id="tt0081573">_Superman II_</span> and <span data-imdb-id="tt0086393">_Superman III_</span>. We learn nothing about Oliver Reed's health problems during filming.
 
-Tonguette mentions Roy Kinnear's fatal accident. He notes the budget was slashed from sixteen to ten million dollars. But he never connects these dots. A tighter budget meant a more grueling schedule. A grueling schedule created dangerous conditions. 
+Tonguette mentions Roy Kinnear's fatal accident. He notes the budget was slashed from sixteen to ten million dollars. But he never connects these dots. A tighter budget meant a more grueling schedule. A grueling schedule created dangerous conditions.
 
 Worse, Tonguette rarely discusses what's actually happening on screen. Instead of describing the scene we're watching, he'll launch into a detailed breakdown of a sight gag in _Superman III_. The commentary becomes a random Lester filmography lecture, disconnected from the movie it's supposed to illuminate.
 

--- a/viewings/2025-07-14-01-the-french-connection-1971.md
+++ b/viewings/2025-07-14-01-the-french-connection-1971.md
@@ -6,6 +6,6 @@ slug: the-french-connection-1971
 medium: Blu-ray
 venue: null
 venueNotes: null
-mediumNotes: '20th Century Fox, 2012 '
+mediumNotes: '20th Century Fox, 2012'
 ---
 


### PR DESCRIPTION
## Summary
- Fixed trailing spaces in mediumNotes fields (4 files)
- Changed "take-away" to "takeaway" for consistency
- Removed trailing spaces from content paragraphs

## Test plan
- [x] All changes are whitespace or minor spelling corrections
- [x] No content or meaning has been altered
- [x] Files still parse correctly as YAML/Markdown

🤖 Generated with [Claude Code](https://claude.ai/code)